### PR TITLE
Fix missing update of long work counter

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -3,7 +3,6 @@ let timeoutID = null;
 let tick = 0;
 let extraBreakCount = 0;
 let longWorkCount = 0;
-let longWorkTick = 0;
 let startTime = Date.now();
 let targetTime = 0;
 const longWorkTime = 1500;
@@ -27,16 +26,19 @@ function post(state, tick, longWorkCount, extraBreakCount)
 function updateLongWork(tick)
 {
     
-    let tempTick = tick % longWorkTime;
-    if(longWorkTick > tempTick)
-        longWorkCount++;
-    
-    if(longWorkCount + extraBreakCount == maxBreakCnt)
+    let tempCount = Math.floor(tick / longWorkTime);
+    let K = 2 * maxBreakCount - 1;
+    if(K**2 - 4 * (2 * tempCount -K) > 0)
     {
-        extraBreakCount++;
+        extraBreakCount = Math.ceil((K-Math.sqrt(K**2 - 4 * (2 * tempCount - K)))/2);
+        longWorkCount = tempCount - (extraBreakCount * maxBreakCount - extraBreakCount * (extraBreakCount - 1)/2);
+    }
+    else
+    {
+        extraBreakCount = maxBreakCount;
         longWorkCount = 0;
     }
-    longWorkTick = tempTick;
+    
 }
 
 
@@ -53,7 +55,6 @@ function update()
     {
         state = 0;
         tick = 0;
-        longWorkTick = 0;
         targetTime = 0;
     }
 
@@ -84,7 +85,6 @@ onmessage = function(e){
     if(state == 0)
     {
         tick = 0;
-        longWorkTick = 0;
         longWorkCount = 0;
         targetTime = 0;
         extraBreakCount = 0;


### PR DESCRIPTION
The long work counter only updated with the website was visible. This was due to the way it counted increments. The longWorkUpdate function has been reworked to compute the counts directly from the tick instead.